### PR TITLE
small docker-compose.yml fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: "3.9"
+name: 'testlink-test'
 networks: 
   testlink:
     name: testlink
@@ -13,7 +14,7 @@ services:
     user: mysql
     command: --default-authentication-plugin=mysql_native_password
     environment:
-    - MYSQL_ROOT_PASSWORD=${MYSQL_ROO}
+    - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT}
     volumes:
     - ${MYSQL_DIR}:/var/lib/mysql
 


### PR DESCRIPTION
fixed typo in docker-compose.yml, where there was a missing letter in variable keeping root password + added name attribute